### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-packaging
+
 AllCops:
   DisplayCopNames: true # Display the name of the failing cops
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :test do
   ruby_version = Gem::Version.new(RUBY_VERSION)
   if ruby_version >= Gem::Version.new('2.1')
     gem 'rubocop', '~> 0.82.0'
+    gem 'rubocop-packaging', '~> 0.1'
     gem 'rubocop-rspec', '~> 1.30.0'
   end
   if ruby_version >= Gem::Version.new('2.0')

--- a/rspec-pending_for.gemspec
+++ b/rspec-pending_for.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/pboling/rspec-pending_for'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir['lib/**/*', 'LICENSE', 'README.md']
   spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rspec-core'


### PR DESCRIPTION
Hi again @pboling :wave: 

Thanks for working on this as well! :heart: 
However, while maintaining this in Debian, we found that this library relies on `git` to list the files which could be done via pure Ruby alternative -- which is what this PR does.

As an addition, this PR makes sure that this gem only ships the required files to the end-users and not other things which are not needed by them :rocket: 

Also, added `rubocop-packaging` as a development_dependency which will ensure the best practices.
Here's what it shows us:
```
➜  rspec-pending_for git:(master)  rubocop --only Packaging

Inspecting 26 files
......................C...

Offenses:

rspec-pending_for.gemspec:16:24: C: Packaging/GemspecGit: Avoid using git to produce lists of files. Downstreams often need to build your package in an environment that does not have git (on purpose). Use some pure Ruby alternative, like Dir or Dir.glob.
  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
                       ^^^^^^^^^^^^^^^^^

26 files inspected, 1 offense detected
```

And this PR fixes the same, which helps us in shipping this in Debian! :tada: 
Hope this would make sense and you'll be open to this change :100: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>